### PR TITLE
Update actions to use v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.target }}-binary
           path: target/${{ matrix.target }}/release/uuml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Download binaries
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.target }}-binary
           path: ./binaries


### PR DESCRIPTION
Update deprecated GitHub Actions versions in release workflow.

* Update the `Upload artifact` step to use `actions/upload-artifact@v3` instead of `v2`.
* Update the `Download binaries` step to use `actions/download-artifact@v3` instead of `v2`.

