### PR TITLE
Fix uuml tool to handle default directory and HTML comments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ fn main() {
     } else if let Some(directory) = matches.get_one::<String>("directory") {
         process_directory(directory);
     } else {
-        println!("Please provide a file or directory.");
+        process_directory(".");
     }
 }
 
@@ -52,12 +52,33 @@ fn process_directory(directory: &str) {
 }
 
 fn replace_umlauts(content: &str) -> String {
-    content
-        .replace("ä", "&auml;")
-        .replace("ö", "&ouml;")
-        .replace("ü", "&uuml;")
-        .replace("Ä", "&Auml;")
-        .replace("Ö", "&Ouml;")
-        .replace("Ü", "&Uuml;")
-        .replace("ß", "&szlig;")
+    let mut result = String::new();
+    let mut in_comment = false;
+
+    for line in content.lines() {
+        if line.contains("<!--") {
+            in_comment = true;
+        }
+        if line.contains("-->") {
+            in_comment = false;
+        }
+
+        if in_comment {
+            result.push_str(line);
+        } else {
+            result.push_str(
+                &line
+                    .replace("ä", "&auml;")
+                    .replace("ö", "&ouml;")
+                    .replace("ü", "&uuml;")
+                    .replace("Ä", "&Auml;")
+                    .replace("Ö", "&Ouml;")
+                    .replace("Ü", "&Uuml;")
+                    .replace("ß", "&szlig;"),
+            );
+        }
+        result.push('\n');
+    }
+
+    result
 }


### PR DESCRIPTION
Update the tool to take the current directory when 'uuml' is called without a flag and path, avoid replacing umlauts inside HTML comments, and fix the linking error in the release workflow.

* **Default Directory Handling**
  - Update `src/main.rs` to default to the current directory if no file or directory is specified.

* **HTML Comments Handling**
  - Update the `replace_umlauts` function in `src/main.rs` to skip HTML comments.

* **Linking Error Fix**
  - No changes made to `.github/workflows/release.yml` as it was not provided in the code changes.

